### PR TITLE
port the README.md to C

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.exe
+!.gitignore

--- a/README.c
+++ b/README.c
@@ -1,0 +1,11 @@
+/* C version of the "免翻墙镜像" project
+ * License: WTFPL
+ * Usage: 
+ * 	gcc -o README.exe README.c
+ * 	./README.exe */
+#include <stdlib.h>
+
+int main(void){
+	/* TODO: don't use external cat, implement the cat inside instead. */
+	return system("cat README.md");
+}


### PR DESCRIPTION
This is the initial C version of the "免翻墙镜像" project, similar as
"README.sh", it asked another cat to read "README.md"!

This commit also add a Git ignore rule to ignore all *.exe files.
Signed-off-by: Ｖ字龍(Vdragon) pika1021@gmail.com
